### PR TITLE
add getting-started/troubleshooting

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -1,0 +1,6 @@
+---
+title: Troubleshooting
+order: 7
+---
+
+TODO: https://github.com/rerun-io/rerun/issues/1045


### PR DESCRIPTION
Add an empty `getting-started/troubleshooting` page.

Will fill later, but we need to decide on the URL now so we can link to it from main readme.

https://github.com/rerun-io/rerun/issues/1294