### PR TITLE
Fix typos and API links

### DIFF
--- a/docs/concepts/apps-and-sessions.md
+++ b/docs/concepts/apps-and-sessions.md
@@ -4,7 +4,7 @@ order: 8
 ---
 
 ## Application ID
-When you initialize rerun with [`rr.init`](https://ref.rerun.io/docs/python/v0.2.0/common/initialization/#rerun.init) you need to set an Application ID.
+When you initialize rerun with [`rr.init`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.init) you need to set an Application ID.
 
 Your Rerun Viewer will store the Blueprint based on this Application ID.
 This means that you can run your app and set up the viewer to your liking,
@@ -18,4 +18,4 @@ This means you can have multiple recordings with different Recording IDs sharing
 
 If you want to log from multiple processes and want all the log data to show up
 together in the viewer, you need to make sure all processes use the same Recording ID.
-You can use [`rr.set_recording_id`](https://ref.rerun.io/docs/python/v0.2.0/common/viewer_control/#rerun.set_recording_id) for this.
+You can use [`rr.set_recording_id`](https://ref.rerun.io/docs/python/latest/common/viewer_control/#rerun.set_recording_id) for this.

--- a/docs/concepts/batches.md
+++ b/docs/concepts/batches.md
@@ -50,7 +50,7 @@ logged array.  When querying a batched component, the component-values are joine
 Logically, this happens as a **left-join** using the "primary" component for the entity. For example, if you log 3
 points and then later log 5 colors, you will still only see 3 points in the viewer.
 
-In the future you will be able to specify the instance keys manually while logging. [#1309](https://github.com/rerun-io/rerun/issues/1309)).
+In the future you will be able to specify the instance keys manually while logging ([#1309](https://github.com/rerun-io/rerun/issues/1309)).
 
 ## Splats
 

--- a/docs/concepts/entity-component.md
+++ b/docs/concepts/entity-component.md
@@ -38,7 +38,7 @@ For more information on the different primitives and how they relate to componen
 
 ### Extension Components
 Your entity could have any number of other components as well. This isn't a problem. Any components that
-aren't relevant to the scene that the space view is drawing are safely ignored. In fact, Rerun even lets you to log you
+aren't relevant to the scene that the space view is drawing are safely ignored. In fact, Rerun even allows you to log your
 own components.
 
 In Python this is done via [log_extension_components](https://ref.rerun.io/docs/python/latest/common/extension_components/#rerun.log_extension_components)

--- a/docs/concepts/entity-component.md
+++ b/docs/concepts/entity-component.md
@@ -34,7 +34,7 @@ how data should be displayed.
 The assorted logging APIs all simply set different combinations of components on some specified entity, and the
 corresponding space views look for entities with these components in the data store.  
 For more information on the different primitives and how they relate to components see the
-[Primitives reference](../reference/primitives.md)
+[Primitives reference](../reference/primitives.md).
 
 ### Extension Components
 Your entity could have any number of other components as well. This isn't a problem. Any components that
@@ -59,5 +59,4 @@ Entities based on the Components they possess.
 
 Rerun does not currently have formalized Systems, although the patterns employed by the Rerun Space Views are very much
 "System like" in their operation. Proper Systems may be a feature investigated in the future
-([#1155](https://github.com/rerun-io/rerun/issues/1155))
-s
+([#1155](https://github.com/rerun-io/rerun/issues/1155)).

--- a/docs/concepts/entity-component.md
+++ b/docs/concepts/entity-component.md
@@ -51,7 +51,7 @@ code-example: extension-components
 ### Empty Entities
 An Entity, without Components, is nothing more than an identity (represented by its Entity
 Path). It contains no data, and has no type. When you log a piece of data, all that you are doing is setting the values
-of of one or more *Components* associated with that *Entity*. 
+of one or more *Components* associated with that *Entity*. 
 
 ## ECS Systems
 In most ECS architectures, there is a third concept we haven't touched on: Systems are processes which operate on the

--- a/docs/concepts/spaces-and-transforms.md
+++ b/docs/concepts/spaces-and-transforms.md
@@ -105,7 +105,7 @@ Note that none of the names in the paths are special.
 
 
 ## View coordinates
-You can use [rerun.log_view_coordinates](https://ref.rerun.io/docs/python/latest/common/transforms/#rerun.log_view_coordinates)) to set your preferred view coordinate systems, giving semantic meaning to the XYZ axes of the space.
+You can use [rerun.log_view_coordinates](https://ref.rerun.io/docs/python/latest/common/transforms/#rerun.log_view_coordinates) to set your preferred view coordinate systems, giving semantic meaning to the XYZ axes of the space.
 
 This is in particular useful when taking the point of view of a given entity in the viewer. The view coordinates will then answer e.g. which axis is forward.
 

--- a/docs/concepts/timelines.md
+++ b/docs/concepts/timelines.md
@@ -7,7 +7,7 @@ order: 3
 Each piece of logged data is associated with one or more timelines.
 By default, each log is added to the `log_time` timeline, with a timestamp assigned by the SDK.
 
-In Python, use the _set time_ functions (`set_time_sequence`, `set_time_seconds`, `set_time_nanos`) to associate logs with other timestamps on other timelines. For example:
+In Python, use the _set time_ functions ([set_time_sequence](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_sequence), [set_time_seconds](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_seconds), [set_time_nanos](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_nanos)) to associate logs with other timestamps on other timelines. For example:
 
 ```python
 for frame in read_sensor_frames():
@@ -28,4 +28,4 @@ Timeless entities belong to all timelines (existing ones, and ones not yet creat
 This is useful for entity that aren't part of normal data capture, but set the scene for how they are shown.
 For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be timeless.
 
-Similarly, coordinate systems (logged with `rr.log_view_coordinates`) are normally timeless.
+Similarly, coordinate systems (logged with [rr.log_view_coordinates](https://ref.rerun.io/docs/python/latest/common/transforms/#rerun.log_view_coordinates)) are normally timeless.

--- a/docs/concepts/timelines.md
+++ b/docs/concepts/timelines.md
@@ -25,7 +25,7 @@ You can then choose which timeline you want to organize your data along in the e
 ## Timeless data
 The logging functions all have `timeless = False` parameters.
 Timeless entities belong to all timelines (existing ones, and ones not yet created) and are shown leftmost in the time panel in the viewer.
-This is useful for entity that aren't part of normal data capture, but set the scene for how they are shown.
+This is useful for entities that aren't part of normal data capture, but set the scene for how they are shown.
 For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be timeless.
 
 Similarly, coordinate systems (logged with [rr.log_view_coordinates](https://ref.rerun.io/docs/python/latest/common/transforms/#rerun.log_view_coordinates)) are normally timeless.

--- a/docs/reference/control-logging.md
+++ b/docs/reference/control-logging.md
@@ -29,6 +29,6 @@ code-example: default-off-session
 ## Dynamically turn logging on/off
 
 * Rust: See the [`is_enabled()`](https://docs.rs/re_sdk/latest/re_sdk/struct.Session.html#method.is_enabled), [`set_enabled()`](https://docs.rs/re_sdk/latest/re_sdk/struct.Session.html#method.set_enabled) methods for Rust.
-* Python: See the [`is_enabled()`](https://ref.rerun.io/docs/python/HEAD/package/rerun/__init__/#rerun.is_enabled), [`set_enabled()`](https://ref.rerun.io/docs/python/HEAD/package/rerun/__init__/#rerun.set_enabled) methods for Python.
+* Python: See the [`is_enabled()`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.is_enabled), [`set_enabled()`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.set_enabled) methods for Python.
 
 code-example: turn-logging-onoff

--- a/docs/reference/sdk-operating-modes.md
+++ b/docs/reference/sdk-operating-modes.md
@@ -20,7 +20,7 @@ This is the default behavior you get when running all of our Python & Rust examp
 
 #### `Python`
 
-Call [`rr.spawn`](https://ref.rerun.io/docs/python/v0.2.0/package/rerun/__init__/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
+Call [`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 #### `Rust`
 
@@ -34,7 +34,7 @@ You will need to start a stand-alone viewer first, either by using `python -m re
 
 #### `Python`
 
-[`rr.connect`](https://ref.rerun.io/docs/python/v0.2.0/package/rerun/__init__/#rerun.connect)
+[`rr.connect`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.connect)
 
 #### `Rust`
 
@@ -46,7 +46,7 @@ This starts the web version of the Rerun Viewer in your browser, and streams dat
 
 #### `Python`
 
-Use [`rr.serve`](https://ref.rerun.io/docs/python/v0.2.0/package/rerun/__init__/#rerun.serve).
+Use [`rr.serve`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.serve).
 
 #### `Rust`
 
@@ -62,7 +62,7 @@ To visualize the saved file, use `python -m rerun path/to/file.rrd` if you've in
 
 #### `Python`
 
-Use [`rr.save`](https://ref.rerun.io/docs/python/v0.2.0/package/rerun/__init__/#rerun.save).
+Use [`rr.save`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.save).
 
 #### `Rust`
 
@@ -72,7 +72,7 @@ Use [`Session::save`](https://docs.rs/rerun/latest/rerun/struct.Session.html#met
 
 We provide helpers for both Python & Rust to effortlessly add and properly handle all of these flags in your programs.
 
-- For Python, checkout the [`script_helpers`](https://ref.rerun.io/docs/python/v0.2.0/package/rerun/script_helpers/) module.
+- For Python, checkout the [`script_helpers`](https://ref.rerun.io/docs/python/latest/package/rerun/script_helpers/) module.
 - For Rust, checkout our [`clap`]() [integration](https://docs.rs/rerun/latest/rerun/clap/index.html).
 
 Have a look at the [official examples](../getting-started/examples.md) to see these helpers in action.


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun-docs/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun-docs/blob/main/CODE_OF_CONDUCT.md)

Fixes a few typos and formatting issues in the docs. Also changes all links to the Python API to `latest` instead of `HEAD` and `vx.x.x`.
