### PR TITLE
Remind users to match versions of SDK and examples

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -7,6 +7,16 @@ order: 6
 
 In the Rerun [GitHub](https://github.com/rerun-io/rerun) repository we maintain a list of examples that demonstrate using the Rerun logging APIs. Generally the examples are individually self-contained, and can be run directly from a Git clone of the repository. Many of the Python examples need additional dependencies set up in a `requirements.txt` next to the example. These are noted in the individual example sections below.
 
+## Setup
+
+Make sure you have the Rerun repository checked out and the latest SDK installed.
+
+```bash
+pip install --upgrade rerun-sdk  # install the latest Rerun SDK
+git clone git@github.com:rerun-io/rerun.git  # Clone the repository
+cd rerun 
+git checkout latest  # Check out the commit matching the latest SDK release
+```
 > Note: Make sure your SDK version matches the examples.
 For example, if your SDK version is `0.3.1`, check out the matching tag
 in the Rerun repository by running `git checkout v0.3.1`.

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -7,6 +7,10 @@ order: 6
 
 In the Rerun [GitHub](https://github.com/rerun-io/rerun) repository we maintain a list of examples that demonstrate using the Rerun logging APIs. Generally the examples are individually self-contained, and can be run directly from a Git clone of the repository. Many of the Python examples need additional dependencies set up in a `requirements.txt` next to the example. These are noted in the individual example sections below.
 
+> Note: Make sure your SDK version matches the examples.
+For example, if your SDK version is `0.3.1`, check out the matching tag
+in the Rerun repository by running `git checkout v0.3.1`.
+
 ## Minimal example
 
 [Python](https://github.com/rerun-io/rerun/tree/latest/examples/python/minimal/main.py) | [Rust](https://github.com/rerun-io/rerun/tree/latest/examples/rust/minimal/src/main.rs)


### PR DESCRIPTION
Update the examples docs page to remind the user to match the version of the SDK to the version of the example code.

![Screenshot 2023-03-20 at 15 19 14](https://user-images.githubusercontent.com/2624717/226368309-695e9429-268a-4df3-a31e-959bb62e0ecb.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)