### PR TITLE
Correct the required rerun dependency

### DIFF
--- a/docs/getting-started/logging-rust.md
+++ b/docs/getting-started/logging-rust.md
@@ -22,7 +22,7 @@ We assume you have a working Rust environment and have started a new project wit
 For this example in particular, we're going to need all of these:
 ```toml
 [dependencies]
-rerun = "0.2.0"
+rerun = "0.4.0"
 itertools = "0.10"
 rand = "0.8"
 ```


### PR DESCRIPTION
This tutorial depends on rerun 0.4.0 (i.e. the use of rerun::native_viewer::spawn), not 0.2.0, as far as I can tell

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
